### PR TITLE
Support kube-control v2 schema

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,7 +8,7 @@ on:
 jobs:
   call-inclusive-naming-check:
     name: Inclusive Naming
-    uses: canonical-web-and-design/Inclusive-naming/.github/workflows/woke.yaml@main
+    uses: canonical/inclusive-naming/.github/workflows/woke.yaml@main
     with:
       fail-on-error: "true"
 
@@ -16,7 +16,7 @@ jobs:
     name: Lint Unit
     uses: charmed-kubernetes/workflows/.github/workflows/lint-unit.yaml@main
     with:
-      python: "['3.8', '3.9', '3.10', '3.11']"
+      python: "['3.8', '3.10', '3.12']"
     needs: 
       - call-inclusive-naming-check
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
 backports.cached-property
-ops>=1.3.0,<2.0.0
+ops
 lightkube>=0.10.1,<1.0.0
 pyyaml
 pydantic==1.*
 ops.manifest>=1.1.0,<2.0.0
-git+https://github.com/charmed-kubernetes/interface-kube-control.git@6dd289d1c795fdeda1bed17873b8d6562227c829#subdirectory=ops
+git+https://github.com/charmed-kubernetes/interface-kube-control.git@KU-1998/use-secrets#subdirectory=ops
 git+https://github.com/charmed-kubernetes/interface-tls-certificates.git@339efe3823b9728d16cdf5bcd1fc3b5de4e68923#subdirectory=ops

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,5 @@ lightkube>=0.10.1,<1.0.0
 pyyaml
 pydantic==1.*
 ops.manifest>=1.1.0,<2.0.0
-git+https://github.com/charmed-kubernetes/interface-kube-control.git@KU-1998/use-secrets#subdirectory=ops
-git+https://github.com/charmed-kubernetes/interface-tls-certificates.git@339efe3823b9728d16cdf5bcd1fc3b5de4e68923#subdirectory=ops
+ops.interface-kube-control @ git+https://github.com/charmed-kubernetes/interface-kube-control.git@edc07bce7ea4c25d472fa4d95834602a7ebce5cd#subdirectory=ops
+ops.interface-tls-certificates @ git+https://github.com/charmed-kubernetes/interface-tls-certificates.git@4a1081da098154b96337a09c8e9c40acff2d330e#subdirectory=ops

--- a/src/charm.py
+++ b/src/charm.py
@@ -6,11 +6,11 @@
 import logging
 from pathlib import Path
 
+import ops
 from ops.charm import CharmBase
 from ops.framework import StoredState
 from ops.interface_kube_control import KubeControlRequirer
 from ops.interface_tls_certificates import CertificatesRequires
-from ops.main import main
 from ops.manifests import Collector, ManifestClientError
 from ops.model import ActiveStatus, BlockedStatus, MaintenanceStatus, WaitingStatus
 
@@ -215,4 +215,4 @@ class AwsCloudProviderCharm(CharmBase):
 
 
 if __name__ == "__main__":
-    main(AwsCloudProviderCharm)
+    ops.main(AwsCloudProviderCharm)

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,5 +1,6 @@
 # Copyright 2022 Canonical Ltd.
 # See LICENSE file for licensing details.
+import asyncio
 import logging
 import random
 import string
@@ -9,6 +10,7 @@ import pytest
 from lightkube import AsyncClient, KubeConfig
 from lightkube.models.meta_v1 import ObjectMeta
 from lightkube.resources.core_v1 import Namespace
+from pytest_operator.plugin import OpsTest
 
 log = logging.getLogger(__name__)
 
@@ -18,20 +20,40 @@ def module_name(request):
     return request.module.__name__.replace("_", "-")
 
 
+async def get_leader(app):
+    """Find leader unit of an application.
+
+    Args:
+        app: Juju application
+
+    Returns:
+        int: index to leader unit
+    """
+    is_leader = await asyncio.gather(*(u.is_leader_from_status() for u in app.units))
+    for idx, flag in enumerate(is_leader):
+        if flag:
+            return idx
+
+
 @pytest.fixture()
-async def kubeconfig(ops_test):
+async def kubeconfig(ops_test: OpsTest):
+    for choice in ["kubernetes-control-plane", "k8s"]:
+        if app := ops_test.model.applications.get(choice):
+            break
+    else:
+        pytest.fail("No kubernetes-control-plane or k8s application found")
+    leader_idx = await get_leader(app)
+    leader = app.units[leader_idx]
+
     kubeconfig_path = ops_test.tmp_path / "kubeconfig"
-    retcode, stdout, stderr = await ops_test.run(
-        "juju",
-        "scp",
-        "kubernetes-control-plane/leader:/home/ubuntu/config",
-        kubeconfig_path,
-    )
+    action = await leader.run_action("get-kubeconfig")
+    data = await action.wait()
+    retcode, kubeconfig = (data.results.get(key, {}) for key in ["return-code", "kubeconfig"])
+
     if retcode != 0:
-        log.error(f"retcode: {retcode}")
-        log.error(f"stdout:\n{stdout.strip()}")
-        log.error(f"stderr:\n{stderr.strip()}")
-        pytest.fail("Failed to copy kubeconfig from kubernetes-control-plane")
+        log.error("Failed to copy kubeconfig from %s (%s)", app.name, data.results)
+        pytest.fail(f"Failed to copy kubeconfig from {app.name}")
+    kubeconfig_path.write_text(kubeconfig)
     assert Path(kubeconfig_path).stat().st_size, "kubeconfig file is 0 bytes"
     yield kubeconfig_path
 
@@ -42,7 +64,7 @@ async def kubernetes(kubeconfig, module_name):
     namespace = f"{module_name}-{rand_str}"
     config = KubeConfig.from_file(kubeconfig)
     client = AsyncClient(
-        config=config.get(context_name="juju-context"),
+        config=config.get(context_name=config.current_context),
         namespace=namespace,
         trust_env=False,
     )

--- a/tox.ini
+++ b/tox.ini
@@ -37,7 +37,7 @@ commands =
 description = Check code against coding style standards
 deps =
     black
-    flake8 < 5.0  # TODO: https://github.com/csachs/pyproject-flake8/issues/13
+    flake8
     flake8-docstrings
     flake8-copyright
     flake8-builtins


### PR DESCRIPTION
### Overview

Make use of https://github.com/charmed-kubernetes/interface-kube-control/pull/2 to support integration of the k8s operator with aws

### Details
* support receiving the ca-cert of the k8s endpoint over the kube-control relation
* support receiving the auth tokens over the kube-control relation via secrets
* use a better group `system:masters` to scope k8s token